### PR TITLE
Multiline comments + Repeat support

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,5 +1,6 @@
 {
   "comments": {
-    "lineComment": "//"
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
   },
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
                 }
             ]
         },
-        "keybindings":[
+        "keybindings": [
             {
                 "command": "p2tas-lang.relativeFromAbsoluteTick",
                 "key": "ctrl+shift+t",

--- a/syntaxes/p2tas.tmLanguage.json
+++ b/syntaxes/p2tas.tmLanguage.json
@@ -40,6 +40,11 @@
 			{
 				"name": "comment",
 				"match": "\\s*//.*"
+			}, 
+			{
+				"name": "comment.block",
+				"begin": "\/\\*",
+				"end": "\\*\/"
 			}]
 		},
 		"loop": {


### PR DESCRIPTION
Multiline comments will now be grayed out like single line comments (added in SAR 1.12.5-pre5).

Repeat support:
- If you now hover over a tick inside of a loop, it will show you the tick count (ignoring the repeat block) and the tick of the start of the repeat block. If you hover below one, it will evaluate the ticks passing in one loop iteration and then multiply it by the number of iterations.
- It also supports nested repeat blocks
- The tick insert command will now error out if used inside of a repeat block (better solution?).

I also optimised the `getTickForLine` function to only look for a previous absolute tick, and not compute it from the beginning.

Also, I'm sorry for the "Merge pull request ..." commits but I don't know how to remove them :(.