### PR TITLE
Add a feature to see the active tools for a line

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -254,7 +254,7 @@ function getToolsForLine(line: number, document: vscode.TextDocument): string[] 
             let amount = lineText.startsWith('+') ? +lineText.substring(1, lineText.indexOf('>')) : undefined;
             decrementCounters((counter) => {
                 if (amount) counter.ticksRemaining -= amount;
-                else counter.ticksRemaining -= counter.totalTicks - (+lineText.substring(0, lineText.indexOf('>')) - counter.startTick);
+                else counter.ticksRemaining = counter.totalTicks - (+lineText.substring(0, lineText.indexOf('>')) - counter.startTick);
             });
         }
 
@@ -269,7 +269,9 @@ function getToolsForLine(line: number, document: vscode.TextDocument): string[] 
                 const args = tool.split(' ');
                 if (args.length < 2) continue;
 
-                if (args[0] === "setang" && args.length === 4) {
+                if (args[0] === "setang") {
+                    if (args.length > 4) continue;
+
                     counters.push(new Counter(result.length, getTickForLine(i, document)[0], +(args[args.length - 1])));
                     result.push(args[0]);
                     continue;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,18 @@ const tokens: { [command: string]: string[]; } = {
     "decel": ["off"]
 };
 
+const activeToolsDisplayDecorationType = vscode.window.createTextEditorDecorationType({
+    after: {
+        color: new vscode.ThemeColor("tab.inactiveForeground"),
+        margin: "10px"
+    }
+});
+
+var activeToolsDisplayDecoration: vscode.DecorationOptions & vscode.DecorationRenderOptions = {
+    range: new vscode.Range(new vscode.Position(0, 0),
+        (vscode.window.activeTextEditor?.document?.lineAt(0)?.range?.end || new vscode.Position(0, 0)))
+}
+
 export function activate(context: vscode.ExtensionContext) {
 
 	const tool_keyword_provider = vscode.languages.registerCompletionItemProvider('p2tas', {
@@ -55,7 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const hoverProvider = vscode.languages.registerHoverProvider('p2tas', {
         provideHover(document: vscode.TextDocument, position: vscode.Position) {
-            const hoveredLineText = document.lineAt(position.line).text;
+            const hoveredLineText = document.lineAt(position.line).text.trim();
 
             if (!hoveredLineText.startsWith('//') && position.character < hoveredLineText.indexOf('>')) {
                 const [tick, loopStartTick] = getTickForLine(position.line, document);
@@ -111,6 +123,184 @@ export function activate(context: vscode.ExtensionContext) {
             else editBuilder.replace(editor!.selection, `+${newTick.toString()}>||||`);
         });
     });
+
+    // Variable used to not refresh multiple times on the same line in onDidChangeTextEditorSelection
+    var previousLine = -1;
+
+    vscode.window.onDidChangeTextEditorSelection(event => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) return;
+
+        const cursorPos = event.selections[0].active;
+
+        if (previousLine === cursorPos.line) {
+            // Refresh the ticks if you change your selection before the '>' !!!UNOPTIMISED!!!!
+            if (cursorPos.character <= editor.document.lineAt(cursorPos.line).text.indexOf('>')) {
+                // FIXME: Maybe don't re-compute everything when something is changed
+                drawActiveToolsDisplay(cursorPos, editor.document);
+                return;
+            }
+            else return;
+        }
+
+        drawActiveToolsDisplay(cursorPos, editor.document);
+        previousLine = cursorPos.line;
+    });
+
+    drawActiveToolsDisplay(vscode.window.activeTextEditor!.selection.active, vscode.window.activeTextEditor!.document);
+}
+
+function drawActiveToolsDisplay(cursorPos: vscode.Position, document: vscode.TextDocument) {
+    const tools = getToolsForLine(cursorPos.line, document).join(', ');
+    activeToolsDisplayDecoration = {
+        range: new vscode.Range(cursorPos, document.lineAt(cursorPos.line).range.end),
+        renderOptions: {
+            after: {
+                contentText: tools.length > 0 ? `Active tools: ${tools}` : "",
+                textDecoration: ";font-size:11px",
+                fontWeight: ";font-weight:lighter"
+            }
+        }
+    };
+    vscode.window.activeTextEditor!.setDecorations(activeToolsDisplayDecorationType, [activeToolsDisplayDecoration]);
+}
+
+function getToolsForLine(line: number, document: vscode.TextDocument): string[] {
+    // Helper class used to count ticks, e.g. for lerped setang.
+    // ticksRemaining is decreased every framebulk, depending it's value.
+    // After it has reached 0, the index-th element of the result array is removed.
+    class Counter {
+        index: number;
+        startTick: number;
+        totalTicks: number;
+        ticksRemaining: number;
+
+        constructor(index: number, startTick: number, ticks: number) {
+            this.index = index;
+            this.startTick = startTick;
+            this.totalTicks = ticks;
+            this.ticksRemaining = ticks;
+        }
+    }
+
+    function decrementCounters(decrement: (counter: Counter) => void) {
+        for (var i = 0; i < counters.length; i++) {
+            const counter = counters[i];
+            decrement(counter);
+
+            // Remove counter since it reached 0
+            if (counter.ticksRemaining <= 0) {
+                // Don't remove the result since autoaim doesn't turn off automatically
+                if (result[counter.index] === "autoaim")
+                    counters.splice(i, 1);
+                else
+                    // removeResult removes the counter as well
+                    removeResult(counter.index);
+
+                i--;
+            }
+        }
+    }
+
+    function removeResult(index: number) {
+        result.splice(index, 1);
+        for (var i = 0; i < counters.length; i++) {
+            if (counters[i].index > index) counters[i].index--;
+            else if (counters[i].index === index) counters.splice(i, 1);
+        }
+    }
+
+    var result: string[] = [];
+    var counters: Counter[] = [];
+    var multilineCommentsOpen = 0;
+    var repeatIterations: number | undefined = undefined;
+    var repeatDuration = 0;
+    for (let i = 0; i <= line; i++) {
+        var lineText = document.lineAt(i).text.trim();
+        if (lineText.startsWith('start') || lineText.startsWith('//') || lineText.length === 0) continue;
+
+        [lineText, multilineCommentsOpen] = withMultilineComments(lineText, multilineCommentsOpen, i, true);
+        if (multilineCommentsOpen > 0 || lineText.length === 0) continue;
+
+        if (lineText.startsWith('repeat')) {
+            const iterations = +lineText.substring(6);
+            if (iterations === 0) {
+                // Skip to the end of the loop, since it has 0 iterations
+                while (!document.lineAt(++i).text.trim().startsWith('end') && i >= line);
+                continue;
+            }
+            else {
+                repeatIterations = iterations;
+                // Move to next line
+                continue;
+            }
+        }
+        else if (lineText.startsWith('end')) {
+            if (repeatIterations) {
+                let amount = repeatDuration * repeatIterations;
+                decrementCounters((counter) => counter.ticksRemaining -= amount);
+            }
+
+            repeatIterations = undefined;
+            repeatDuration = 0;
+
+            // Move to next line
+            continue;
+        }
+
+        if (repeatIterations)
+            repeatDuration += +lineText.substring(1, lineText.indexOf('>'));
+        else {
+            let amount = lineText.startsWith('+') ? +lineText.substring(1, lineText.indexOf('>')) : undefined;
+            decrementCounters((counter) => {
+                if (amount) counter.ticksRemaining -= amount;
+                else counter.ticksRemaining -= counter.totalTicks - (+lineText.substring(0, lineText.indexOf('>')) - counter.startTick);
+            });
+        }
+
+        // We need to decrement the counters, changes in the line you are hovering over should be ignored
+        if (i === line) break;
+
+        // Only if the line has four "|" in it
+        if (lineText.split("|").length - 1 === 4) {
+            const tools = lineText.substring(lineText.lastIndexOf('|') + 1).split(';').map((value, index) => value.trim());
+            for (const tool of tools) {
+                // Tool arguments e.g.: [autoaim, off]
+                const args = tool.split(' ');
+                if (args.length < 2) continue;
+
+                if (args[0] === "setang" && args.length === 4) {
+                    counters.push(new Counter(result.length, getTickForLine(i, document)[0], +(args[args.length - 1])));
+                    result.push(args[0]);
+                    continue;
+                }
+                else if (args[0] === "autoaim" && args.length === 5) {
+                    counters.push(new Counter(result.length, getTickForLine(i, document)[0], +(args[args.length - 1])));
+                    result.push(args[0]);
+                    continue;
+                }
+                else if (args[0] === "decel") {
+                    if (result.indexOf(args[0]) === -1)
+                        result.push(`(${args[0]})`);
+                    continue;
+                }
+
+                if (args[1] === "off")
+                    // Remove tool from the list
+                    removeResult(result.indexOf(args[0]));
+                else {
+                    // Tool is already in the list
+                    if (result.indexOf(args[0]) !== -1) continue;
+                    result.push(args[0]);
+                }
+            }
+        }
+    }
+
+    for (var counter of counters)
+        result[counter.index] += ` (${counter.ticksRemaining} ticks left)`;
+
+    return result;
 }
 
 // Returns the tick count and the tick count of the start of a repeat block
@@ -190,12 +380,13 @@ function getTicksPassingLoop(document: vscode.TextDocument, index: number): [num
         return [0, index];
 }
 
-function withMultilineComments(lineText: string, multilineCommentsOpen: number, line: number): [string, number] {
+function withMultilineComments(lineText: string, multilineCommentsOpen: number, line: number, reversed: Boolean = false): [string, number] {
     const multilineCommentOpenToken = lineText.indexOf('/*');
         const multilineCommentCloseToken = lineText.indexOf('*/');
         if (multilineCommentOpenToken !== -1 && multilineCommentCloseToken === -1) {
-            multilineCommentsOpen--;
-            if (multilineCommentsOpen < 0) {
+            // Add one if we're reversed, otherwise subtract one
+            multilineCommentsOpen -= !reversed ? 1 : -1;
+            if (!reversed && multilineCommentsOpen < 0) {
                 // Commment was opened but never closed
                 // FIXME: Show error line under the token. This can be done using a diagnostic collection, however,
                 //  this should be checked for every time something is changed in the file, and not suddently appear when hovering.
@@ -207,7 +398,14 @@ function withMultilineComments(lineText: string, multilineCommentsOpen: number, 
         }
         if (lineText.indexOf('*/') !== -1) {
             if (multilineCommentOpenToken === -1) {
-                multilineCommentsOpen++;
+                // Subtract one if we're reversed, otherwise add one
+                multilineCommentsOpen += !reversed ? 1 : -1;
+                if (reversed && multilineCommentsOpen < 0) {
+                    // Commment was opened but never closed. See FIXME above!
+                    vscode.window.showErrorMessage(`Comment was opened but never closed! (line: ${++line}, column: ${multilineCommentCloseToken})`);
+                    return ["", 0];
+                }
+
                 lineText = lineText.substring(multilineCommentCloseToken + 2);
             }
             else


### PR DESCRIPTION
At the end of the line your cursor is in, you will now see a piece of non-editable piece of text that shows the active tools for that line and, if they take longer (e.g. lerped setang / autoaim), how many ticks are left. (#3)

I need to apologize for my inability to work with git again. I seem to have somehow duplicated the commits. Maybe you can still merge it since the diff shows the correct changes but if that doesn't work I honestly have no idea...

Commits that were added in the previous pull request:
- Add multiline comment highlighting (6f273f8)
- Add repeat support (18b66eb)
- Merge pull request #1 from david072/repeat-support (dd75eaa)
- Merge pull request #2 from david072/multiline-comments (31d546f)
- Optimise getTickForLine to look for previous absolute tick (151fbdc)
- Ignore multiline comments in getTickForLine() (d739d98)
- Add support for infinitely nested repeat blocks (aa09b5b)
- Move the code for ignoring multiline comments into a function (f5cc672)
- The contents of "Resolve merge conflicts" (7d4fbac)