### PR TITLE
Fixes

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -30,7 +30,7 @@ var activeToolsDisplayDecoration: vscode.DecorationOptions & vscode.DecorationRe
 var onDidChangeTextEditorSelectionDisposable: Disposable;
 
 export function activate(context: vscode.ExtensionContext) {
-    var configuration = vscode.workspace.getConfiguration('p2tas-lang')
+    var configuration = vscode.workspace.getConfiguration('p2tas-lang');
 
     // Language client
     let serverModule = context.asAbsolutePath(path.join('server', 'out', 'server.js'));
@@ -202,12 +202,12 @@ export function activate(context: vscode.ExtensionContext) {
         configuration = vscode.workspace.getConfiguration('p2tas-lang')
 
         if (e.affectsConfiguration("p2tas-lang.showActiveToolsDisplay")) {
-            console.log(configuration.get("showActiveToolsDisplay"));
             if (configuration.get<boolean>("showActiveToolsDisplay")) {
                 onDidChangeTextEditorSelectionDisposable = registerActiveToolsDisplay();
             }
             else {
-                onDidChangeTextEditorSelectionDisposable.dispose();
+                onDidChangeTextEditorSelectionDisposable?.dispose();
+                onDidChangeTextEditorSelectionDisposable = undefined;
             }
         }
 
@@ -225,7 +225,6 @@ function registerActiveToolsDisplay(): Disposable {
         const cursorPos = event.selections[0].active;
         drawActiveToolsDisplay(cursorPos, editor.document);
     });
-
 }
 
 async function drawActiveToolsDisplay(cursorPos: vscode.Position, document: vscode.TextDocument) {

--- a/client/src/sidebar.ts
+++ b/client/src/sidebar.ts
@@ -67,7 +67,7 @@ export class TASSidebarProvider implements vscode.WebviewViewProvider {
             }
         });
 
-        this._view?.webview.postMessage({reset: 1});
+        this._view?.webview.postMessage({ reset: 1 });
     }
 
     private _getHtmlForWebview(webview: vscode.Webview) {
@@ -208,7 +208,8 @@ export class TASSidebarProvider implements vscode.WebviewViewProvider {
             connected: this.server.connected,
             state: TASStatus[this.server.status],
             rate: this.server.playbackRate,
-            currentTick: this.server.currentTick
+            currentTick: this.server.currentTick,
+            confirmFieldChanges: this.server.userConfirmFieldChanges,
         };
         this._view?.webview.postMessage(message);
     }

--- a/client/src/sidebarScript.js
+++ b/client/src/sidebarScript.js
@@ -31,6 +31,8 @@ const pauseatBox = document.querySelector("#pauseat-input");
 const linkButton = document.querySelector("#link");
 const linkIndicator = document.querySelector("#link-disabled");
 
+var confirmFieldChanges = true;
+
 // Runtime data
 let connected = false;
 let rawPlayback = false;
@@ -109,6 +111,11 @@ rateSlider.addEventListener('input', () => {
 rateSlider.addEventListener('mouseup', event => {
     if (event.button !== 0) return;
 
+    if (!confirmFieldChanges) {
+        changeRate();
+        return;
+    }
+
     // Then, set the visibility of the checkmark for the user to confirm the change
     if (rateBox.value !== playbackRate) { // Check if value has changed
         rateButton.classList.remove("unchanged"); // Show set button
@@ -120,6 +127,11 @@ rateSlider.addEventListener('mouseup', event => {
 });
 
 rateBox.addEventListener('keyup', key => {
+    if (!confirmFieldChanges) {
+        changeRate();
+        return;
+    }
+
     if (key.code === "Enter") changeRate();
 
     if (rateBox.value !== playbackRate) { // Check if value has changed
@@ -140,6 +152,11 @@ rateButton.addEventListener('keyup', key => {
 });
 
 skipBox.addEventListener('keyup', key => {
+    if (!confirmFieldChanges) {
+        fastForward();
+        return;
+    }
+
     if (key.code === "Enter") fastForward();
 
     if (skipBox.value !== skipToTick) { // Check if value has changed
@@ -160,6 +177,11 @@ skipButton.addEventListener('keyup', key => {
 });
 
 pauseatBox.addEventListener('keyup', key => {
+    if (!confirmFieldChanges) {
+        nextPause();
+        return;
+    }
+
     if (key.code === "Enter") nextPause();
 
     if (pauseatBox.value !== pauseAtTick) { // Check if value has changed
@@ -292,13 +314,15 @@ function handleMessage(message) {
         dataRateText.style.color = "var(--vscode-charts-lines)";
         dataTickText.style.color = "var(--vscode-charts-lines)";
     }
+
+    confirmFieldChanges = message.confirmFieldChanges;
 }
 
 function changeRate() {
     let rate = +rateBox.value;
     vscode.postMessage({ type: 'changeRate', rate: rate });
     playbackRate = rateBox.value;
-    unfocusButton(rateButton);
+    if (confirmFieldChanges) unfocusButton(rateButton);
 }
 
 function fastForward() {
@@ -312,14 +336,14 @@ function fastForward() {
         pauseatBox.value = skipBox.value;
     }
 
-    unfocusButton(skipButton);
+    if (confirmFieldChanges) unfocusButton(skipButton);
 }
 
 function nextPause() {
     let tick = +pauseatBox.value;
     vscode.postMessage({ type: 'nextPause', tick: tick });
     pauseAtTick = pauseatBox.value;
-    unfocusButton(pauseatButton);
+    if (confirmFieldChanges) unfocusButton(pauseatButton);
 }
 
 function setPlayImage(playing) {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,26 @@
                     "contextualTitle": "TAS integration"
                 }
             ]
+        },
+        "configuration": {
+            "title": "P2-TAS Tools Language",
+            "properties": {
+                "p2tas-lang.showActiveToolsDisplay": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show a piece of text at the end of the current line, showing the currently active tools in their execution order."
+                },
+                "p2tas-lang.confirmFieldChangesInSidebar": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Ask for confirmation when changing fields in the sidebar."
+                },
+                "p2tasLanguageServer.doErrorChecking": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Check the current file for errors."
+                }
+            }
         }
     },
     "activationEvents": [

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -318,7 +318,7 @@ connection.onRequest("p2tas/toggleLineTickType", (params: [any, number]) => {
 	const line = script.lines.get(lineNumber);
 	if (line === undefined) return "";
 
-	if (line.type !== LineType.Framebulk) return "";
+	if (line.type !== LineType.Framebulk) return line.lineText;
 
 	if (!line.isRelative) {
 		// Switch from absolute to relative

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -12,8 +12,6 @@ import { endCompletion, repeatCompletion, startCompletion, startTypes } from './
 import { LineType, ScriptLine, TASScript } from './tas-script/tasScript';
 import { TASTool } from './tas-script/tasTool';
 import { TokenType } from './tas-script/tokenizer';
-// import { TASTool } from './_tas-script/tasTool';
-// import { CompletionItemDeclaration, endCompletion, startCompletion, startTypes } from './_tas-script/util';
 
 const connection = createConnection(ProposedFeatures.all);
 const documents: Map<string, TASScript> = new Map();

--- a/server/src/tas-script/otherCompletion.ts
+++ b/server/src/tas-script/otherCompletion.ts
@@ -23,6 +23,7 @@ export const startTypes: CompletionDefinition = {
 };
 
 type CompletionItem = { name: string, description: string };
-export const startCompletion: CompletionItem = { name: "start", description: "**Syntax:** ```start <map|save|cm|now|next>```\n\nDefines how the TAS should start. Must be the first statement in a script." };
+export const versionCompletion: CompletionItem = { name: "version", description: "**Syntax:** ```version <1/2/3/4>```\n\nDefines the version to use. This must be the first statement in a script. The number lets the TAS tools know which version to use, to allow for backwards compatibility with older scripts." }
+export const startCompletion: CompletionItem = { name: "start", description: "**Syntax:** ```start <map|save|cm|now|next>```\n\nDefines how the TAS should start. Must be the second statement in a script, preceeded by a `version` statement." };
 export const repeatCompletion: CompletionItem = { name: "repeat", description: "**Syntax:** ```repeat <iterations>```\n\nMarks the start of a repeat block with given iterations. Must have a corresponding ```end``` statement later down in the file." };
 export const endCompletion: CompletionItem = { name: "end", description: "**Syntax:** ```end```\n\nMarks the end of a loop. Must have a corresponding ```repeat``` further up in the file." };

--- a/server/src/tas-script/tasScript.ts
+++ b/server/src/tas-script/tasScript.ts
@@ -67,7 +67,7 @@ export class TASScript {
                     const startType = this.expectText("Expected start type", "map", "save", "cm", "now", "next");
 
                     const checkStartTypeWithNumber = (startType: string, isNested: boolean): boolean => {
-                        if (startType !== "map" && startType !== "save") return false;
+                        if (startType !== "map" && startType !== "save" && startType !== "cm") return false;
 
                         if (!this.isNextType(TokenType.Number)) return false;
 

--- a/server/src/tas-script/tasScript.ts
+++ b/server/src/tas-script/tasScript.ts
@@ -247,7 +247,7 @@ export class TASScript {
         else if (state === ParserState.Start) {
             DiagnosticCollector.addDiagnosticToLine(integer.MAX_VALUE, 0, "Expected start line");
         }
-        else if (state === ParserState.Framebulks && isFirstFramebulk) {
+        else if ((state === ParserState.RngManip || state === ParserState.Framebulks) && isFirstFramebulk) {
             DiagnosticCollector.addDiagnosticToLine(integer.MAX_VALUE, 0, "Expected framebulks");
         }
 

--- a/server/src/tas-script/tasScript.ts
+++ b/server/src/tas-script/tasScript.ts
@@ -8,6 +8,8 @@ enum ParserState {
 }
 
 export class TASScript {
+    fileText = "";
+
     lines = new Map<number, ScriptLine>();
 
     scriptVersion = 4;
@@ -25,15 +27,19 @@ export class TASScript {
         return entries[i][1];
     }
 
-    parse(fileText: string): Diagnostic[] {
+    parse(fileText?: string): Diagnostic[] {
         new DiagnosticCollector();
+
+        if (fileText !== undefined) {
+            this.fileText = fileText;
+        }
 
         this.lineIndex = 0;
         this.tokenIndex = 0;
         this.lines = new Map<number, ScriptLine>();
 
         var lines: string[] = [];
-        [this.tokens, lines] = tokenize(fileText);
+        [this.tokens, lines] = tokenize(this.fileText);
 
         var state = ParserState.Version;
         var isFirstFramebulk = true;

--- a/server/src/tas-script/tasScript.ts
+++ b/server/src/tas-script/tasScript.ts
@@ -136,7 +136,7 @@ export class TASScript {
                     state = ParserState.Framebulks;
                     break;
                 case ParserState.Framebulks:
-                    const prevLine = this.previousLine()!;    
+                    const prevLine = this.previousLine()!;
 
                     if (this.isNextType(TokenType.String)) {
                         const token = this.tokens[this.lineIndex][this.tokenIndex - 1];
@@ -202,10 +202,6 @@ export class TASScript {
                         }
                     }
 
-                    // Sort tools according to their priority index from SAR if version >= 3
-                    if (this.scriptVersion >= 3)
-                        activeTools.sort((a, b) => TASTool.tools[a.tool].index - TASTool.tools[b.tool].index);
-
                     blk: {
                         if (!isToolBulk) {
                             // Movement field
@@ -239,6 +235,10 @@ export class TASScript {
                             DiagnosticCollector.addDiagnosticToLine(token.line, token.end, "Unexpected tokens");
                         }
                     }
+
+                    // Sort tools according to their priority index from SAR if version >= 3
+                    if (this.scriptVersion >= 3)
+                        activeTools.sort((a, b) => TASTool.tools[a.tool].index - TASTool.tools[b.tool].index);
 
                     this.lines.set(
                         currentLine,

--- a/server/src/tas-script/tasScript.ts
+++ b/server/src/tas-script/tasScript.ts
@@ -174,7 +174,7 @@ export class TASScript {
                     const tick = this.expectNumber("Expected tick") || 0;
 
                     const angleToken = this.expectType("Expected '>' or '>>'", TokenType.RightAngle, TokenType.DoubleRightAngle);
-                    const skipToTools = angleToken !== undefined && angleToken.type === TokenType.DoubleRightAngle;
+                    const isToolBulk = angleToken !== undefined && angleToken.type === TokenType.DoubleRightAngle;
 
                     var activeTools = this.previousLine()!.activeTools.map((val) => val.copy());
 
@@ -202,7 +202,7 @@ export class TASScript {
                         activeTools.sort((a, b) => TASTool.tools[a.tool].index - TASTool.tools[b.tool].index);
 
                     blk: {
-                        if (!skipToTools) {
+                        if (!isToolBulk) {
                             // Movement field
                             this.expectVector();
                             if (this.tokens[this.lineIndex].length <= this.tokenIndex) break blk;
@@ -235,7 +235,17 @@ export class TASScript {
                         }
                     }
 
-                    this.lines.set(currentLine, new ScriptLine(currentLineText, absoluteTick, isRelative, LineType.Framebulk, activeTools, this.tokens[this.lineIndex]));
+                    this.lines.set(
+                        currentLine,
+                        new ScriptLine(
+                            currentLineText,
+                            absoluteTick,
+                            isRelative,
+                            !isToolBulk ? LineType.Framebulk : LineType.ToolBulk,
+                            activeTools,
+                            this.tokens[this.lineIndex]
+                        )
+                    );
                     isFirstFramebulk = false;
                 default:
                     break;
@@ -577,6 +587,7 @@ export enum LineType {
     RepeatStart,
     End,
     Framebulk,
+    ToolBulk,
     Empty,
 }
 

--- a/server/src/tas-script/tasTool.ts
+++ b/server/src/tas-script/tasTool.ts
@@ -5,7 +5,7 @@ export namespace TASTool {
         constructor(
             public tool: string,
             public ticksRemaining?: number
-        ) {}
+        ) { }
 
         copy(): Tool {
             return new Tool(this.tool, this.ticksRemaining);
@@ -19,6 +19,7 @@ export namespace TASTool {
             readonly durationIndex: number,
             readonly arguments: ToolArgument[],
             readonly description: string,
+            readonly index: number, // priority index from SAR (- 1) (used only in version >= 3)
         }
     }
 
@@ -53,7 +54,8 @@ export namespace TASTool {
                 { type: TokenType.Number, unit: "ups", required: false },
                 { type: TokenType.Number, unit: "deg", required: false },
             ],
-            description: "**Syntax:** ```strafe [parameters]```\n\nThe strafe tool will adjust player input to get a different kind of strafing depending on parameters.\n\n**Example:** ```strafe 299.999ups left veccam```"
+            description: "**Syntax:** ```strafe [parameters]```\n\nThe strafe tool will adjust player input to get a different kind of strafing depending on parameters.\n\n**Example:** ```strafe 299.999ups left veccam```",
+            index: 5,
         },
         autojump: {
             isOrderDetermined: true,
@@ -62,7 +64,8 @@ export namespace TASTool {
             arguments: [
                 { text: "on", type: TokenType.String, required: false, description: "Enables ```autojump```." },
             ],
-            description: "**Syntax:** ```autojump [on]```\n\nAnything other than ```on``` will disable the tool.\n\nAutojump tool will change the jump button state depending on whether the player is grounded or not, resulting in automatically jumping on the earliest contact with a ground.\n\n**Example:** ```autojump on```"
+            description: "**Syntax:** ```autojump [on]```\n\nAnything other than ```on``` will disable the tool.\n\nAutojump tool will change the jump button state depending on whether the player is grounded or not, resulting in automatically jumping on the earliest contact with a ground.\n\n**Example:** ```autojump on```",
+            index: 3,
         },
         absmov: {
             isOrderDetermined: true,
@@ -73,6 +76,7 @@ export namespace TASTool {
                 { type: TokenType.Number, required: false },
             ],
             description: "**Syntax:** ```absmov <angle> [strength]```\n\nAbsolute movement tool will generate movement values depending on the absolute move direction you provide in degrees. Giving off as an argument will disable the tool. The strength parameter must be between 0 and 1 (default) and controls how fast the player will move.\n\n**Example:** ```absmov 90 0.5```",
+            index: 4,
         },
         setang: {
             isOrderDetermined: true,
@@ -83,7 +87,8 @@ export namespace TASTool {
                 { type: TokenType.Number, required: true },
                 { type: TokenType.Number, required: false },
             ],
-            description: "**Syntax:** ```setang <pitch> <yaw> [time]```\n\nThis tool works basically the same as setang console command. It will adjust the view analog in a way so the camera is looking towards given angles.\n\n**Example:** ```setang 0 0 20```"
+            description: "**Syntax:** ```setang <pitch> <yaw> [time]```\n\nThis tool works basically the same as setang console command. It will adjust the view analog in a way so the camera is looking towards given angles.\n\n**Example:** ```setang 0 0 20```",
+            index: 1,
         },
         autoaim: {
             isOrderDetermined: true,
@@ -95,7 +100,8 @@ export namespace TASTool {
                 { type: TokenType.Number, required: true },
                 { type: TokenType.Number, required: false },
             ],
-            description: "**Syntax:** ```autoaim <x> <y> <z> [time]```\n\nThe Auto Aim tool will automatically aim towards a specified point in 3D space.\n\n**Example:** ```autoaim 0 0 0 20```"
+            description: "**Syntax:** ```autoaim <x> <y> <z> [time]```\n\nThe Auto Aim tool will automatically aim towards a specified point in 3D space.\n\n**Example:** ```autoaim 0 0 0 20```",
+            index: 2,
         },
         decel: {
             isOrderDetermined: true,
@@ -104,7 +110,8 @@ export namespace TASTool {
             arguments: [
                 { type: TokenType.Number, unit: "ups?", required: false },
             ],
-            description: "**Syntax:** ```decel <speed>```\n\nThe decelaration tool will slow down as quickly as possible to the given speed.\n\n**Example:** ```decel 100```"
+            description: "**Syntax:** ```decel <speed>```\n\nThe decelaration tool will slow down as quickly as possible to the given speed.\n\n**Example:** ```decel 100```",
+            index: 6,
         },
         check: {
             isOrderDetermined: true,
@@ -123,7 +130,8 @@ export namespace TASTool {
                 { text: "angepsilon", type: TokenType.String, required: false, enablesUpTo: 10 },
                 { type: TokenType.Number, required: true },
             ],
-            description: "**Syntax:** ```check [pos x y z] [ang pitch yaw] [posepsilon val] [angepsilon val]```\n\nThe check tool accepts a target position and angle, and a precision value (posepsilon (default: 0.5), angepsilon (default: 0.2)). **Before** the tick it is on, it will check whether the player position is close to (meaning \"within posepsilon / angepsilon units\") the target position, and if not, replay the active script. It will do this a maximum of ```sar_tas_check_max_replays``` (default 15) times.\n\n**Example:** ```check pos 100 250 312.7```"
+            description: "**Syntax:** ```check [pos x y z] [ang pitch yaw] [posepsilon val] [angepsilon val]```\n\nThe check tool accepts a target position and angle, and a precision value (posepsilon (default: 0.5), angepsilon (default: 0.2)). **Before** the tick it is on, it will check whether the player position is close to (meaning \"within posepsilon / angepsilon units\") the target position, and if not, replay the active script. It will do this a maximum of ```sar_tas_check_max_replays``` (default 15) times.\n\n**Example:** ```check pos 100 250 312.7```",
+            index: 0,
         }
     };
 }

--- a/server/src/tas-script/tasTool.ts
+++ b/server/src/tas-script/tasTool.ts
@@ -30,7 +30,8 @@ export namespace TASTool {
             readonly text?: string,
             readonly unit?: string, // if it ends with a '?', it's optional (see absmov)
             readonly description?: string,
-            readonly enablesUpTo?: number,
+            readonly children?: ToolArgument[],
+            readonly otherwiseChildren?: ToolArgument[], // children if this argument didn't match (better name pls?)
         ) { }
     }
 
@@ -95,9 +96,15 @@ export namespace TASTool {
             hasOff: true,
             durationIndex: 3,
             arguments: [
-                { type: TokenType.Number, required: true },
-                { type: TokenType.Number, required: true },
-                { type: TokenType.Number, required: true },
+                {
+                    type: TokenType.String, text: "ent", required: false, children: [
+                        { type: TokenType.String, required: true },
+                    ], otherwiseChildren: [
+                        { type: TokenType.Number, required: true },
+                        { type: TokenType.Number, required: true },
+                        { type: TokenType.Number, required: true },
+                    ]
+                },
                 { type: TokenType.Number, required: false },
             ],
             description: "**Syntax:** ```autoaim <x> <y> <z> [time]```\n\nThe Auto Aim tool will automatically aim towards a specified point in 3D space.\n\n**Example:** ```autoaim 0 0 0 20```",
@@ -118,17 +125,29 @@ export namespace TASTool {
             hasOff: false,
             durationIndex: -1,
             arguments: [
-                { text: "pos", type: TokenType.String, required: false, enablesUpTo: 3 },
-                { type: TokenType.Number, required: true },
-                { type: TokenType.Number, required: true },
-                { type: TokenType.Number, required: true },
-                { text: "ang", type: TokenType.String, required: false, enablesUpTo: 6 },
-                { type: TokenType.Number, required: true },
-                { type: TokenType.Number, required: true },
-                { text: "posepsilon", type: TokenType.String, required: false, enablesUpTo: 8 },
-                { type: TokenType.Number, required: true },
-                { text: "angepsilon", type: TokenType.String, required: false, enablesUpTo: 10 },
-                { type: TokenType.Number, required: true },
+                {
+                    text: "pos", type: TokenType.String, required: false, children: [
+                        { type: TokenType.Number, required: true },
+                        { type: TokenType.Number, required: true },
+                        { type: TokenType.Number, required: true },
+                    ]
+                },
+                {
+                    text: "ang", type: TokenType.String, required: false, children: [
+                        { type: TokenType.Number, required: true },
+                        { type: TokenType.Number, required: true },
+                    ]
+                },
+                {
+                    text: "posepsilon", type: TokenType.String, required: false, children: [
+                        { type: TokenType.Number, required: true },
+                    ]
+                },
+                {
+                    text: "angepsilon", type: TokenType.String, required: false, children: [
+                        { type: TokenType.Number, required: true },
+                    ]
+                },
             ],
             description: "**Syntax:** ```check [pos x y z] [ang pitch yaw] [posepsilon val] [angepsilon val]```\n\nThe check tool accepts a target position and angle, and a precision value (posepsilon (default: 0.5), angepsilon (default: 0.2)). **Before** the tick it is on, it will check whether the player position is close to (meaning \"within posepsilon / angepsilon units\") the target position, and if not, replay the active script. It will do this a maximum of ```sar_tas_check_max_replays``` (default 15) times.\n\n**Example:** ```check pos 100 250 312.7```",
             index: 0,

--- a/server/src/tas-script/tokenizer.ts
+++ b/server/src/tas-script/tokenizer.ts
@@ -51,7 +51,7 @@ function removeComments(tokens: Token[][]) {
                     tokens[lineIndex].splice(tokenIndex, 1);
                     continue;
                 }
-                
+
                 if (lineIndex === multilineCommentStartLine) {
                     tokens[lineIndex].splice(multilineCommentStartIndex, tokenIndex - multilineCommentStartIndex + 1)
                     tokenIndex = multilineCommentStartIndex;
@@ -166,6 +166,12 @@ namespace Tokenizer {
             while (accept(numberPredicate));
             accept(anyOf("."));
             while (accept(numberPredicate));
+
+            if (accept(anyOf("e"))) {
+                if (!accept(numberPredicate)) return TokenType.String;
+                while (accept(numberPredicate));
+            }
+
             return TokenType.Number;
         }
 
@@ -181,7 +187,7 @@ namespace Tokenizer {
 
         switch (c) {
             case "+": return TokenType.Plus;
-            case ">": 
+            case ">":
                 if (accept(anyOf(">"))) return TokenType.DoubleRightAngle;
                 else return TokenType.RightAngle;
             case "|": return TokenType.Pipe;
@@ -189,10 +195,10 @@ namespace Tokenizer {
             case "/":
                 if (accept(anyOf("/"))) return TokenType.SingleLineComment;
                 else if (accept(anyOf("*"))) return TokenType.MultilineCommentOpen;
-                return TokenType.String; // ?
+                return TokenType.String;
             case "*":
                 if (accept(anyOf("/"))) return TokenType.MultilineCommentClose;
-                return TokenType.String; // ?
+                return TokenType.String;
             default: return TokenType.String;
         }
     }

--- a/server/src/tas-script/tokenizer.ts
+++ b/server/src/tas-script/tokenizer.ts
@@ -146,7 +146,9 @@ namespace Tokenizer {
         return false;
     }
 
-    function anyOf(chars: string): (str: string) => boolean {
+    type Predicate = (str: string) => boolean;
+
+    function anyOf(chars: string): Predicate {
         return (str: string): boolean => chars.indexOf(str) !== -1;
     }
 

--- a/syntaxes/p2tas.tmLanguage.json
+++ b/syntaxes/p2tas.tmLanguage.json
@@ -39,7 +39,7 @@
 			},
 			{
 				"name": "variable.parameter",
-				"match": "\\b(on|off|none|vec|ang|veccam|max|keep|forward|forwardvel|left|right|nopitchlock|letspeedlock|pos|posepsilon|angepsilon)\\b"
+				"match": "\\b(on|off|none|vec|ang|veccam|max|keep|forward|forwardvel|left|right|nopitchlock|letspeedlock|pos|posepsilon|angepsilon|ent)\\b"
 			},
 			{
 				"name": "ups_or_deg",

--- a/syntaxes/p2tas.tmLanguage.json
+++ b/syntaxes/p2tas.tmLanguage.json
@@ -35,11 +35,11 @@
 		"framebulk": {
 			"patterns": [{
 				"name": "keyword.other.tools_args",
-				"match": "\\b(strafe|autojump|absmov|setang|autoaim|decel|check)\\b"
+				"match": "\\b((?<=.*(\\|[^\\|]*){4})|(?<=.*>>.*))(strafe|autojump|absmov|setang|autoaim|decel|check)\\b"
 			},
 			{
 				"name": "variable.parameter",
-				"match": "\\b(on|off|none|vec|ang|veccam|max|keep|forward|forwardvel|left|right|nopitchlock|letspeedlock|pos|posepsilon|angepsilon|ent)\\b"
+				"match": "\\b((?<=.*(\\|[^\\|]*){4})|(?<=.*>>.*))(on|off|none|vec|ang|veccam|max|keep|forward|forwardvel|left|right|nopitchlock|letspeedlock|pos|posepsilon|angepsilon|ent)\\b"
 			},
 			{
 				"name": "ups_or_deg",

--- a/syntaxes/p2tas.tmLanguage.json
+++ b/syntaxes/p2tas.tmLanguage.json
@@ -35,11 +35,11 @@
 		"framebulk": {
 			"patterns": [{
 				"name": "keyword.other.tools_args",
-				"match": "\\b((?<=.*(\\|[^\\|]*){4})|(?<=.*>>.*))(strafe|autojump|absmov|setang|autoaim|decel|check)\\b"
+				"match": "\\b(?<=(.*(\\|[^\\|]*){4})|(.*>>.*))(strafe|autojump|absmov|setang|autoaim|decel|check)\\b"
 			},
 			{
 				"name": "variable.parameter",
-				"match": "\\b((?<=.*(\\|[^\\|]*){4})|(?<=.*>>.*))(on|off|none|vec|ang|veccam|max|keep|forward|forwardvel|left|right|nopitchlock|letspeedlock|pos|posepsilon|angepsilon|ent)\\b"
+				"match": "\\b(?<=(.*(\\|[^\\|]*){4})|(.*>>.*))(on|off|none|vec|ang|veccam|max|keep|forward|forwardvel|left|right|nopitchlock|letspeedlock|pos|posepsilon|angepsilon|ent)\\b"
 			},
 			{
 				"name": "ups_or_deg",

--- a/syntaxes/p2tas.tmLanguage.json
+++ b/syntaxes/p2tas.tmLanguage.json
@@ -2,6 +2,8 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Portal 2 TAS script",
 	"patterns": [{"include": "#version"}, {"include": "#start"}, {"include": "#rngmanip"}, {"include": "#framebulk"}, {"include": "#loop"}],
+	"foldingStartMarker": "^\\s*repeat",
+	"foldingStopMarker": "^\\s*end",
 	"repository": {
 		"version": {
 			"patterns": [{


### PR DESCRIPTION
This fixes / implements some issues :^)

- Adds settings for the user (fix #6)
    - Whether to display the active tools display
    - Whether to ask the user for configuration when changing fields in the sidebar
    - Whether the language server should emit diagnostics
- Scientific notation parsing for numbers in the tokenizer (fix #31)
- Error for out-of-order tick numbers (fix #32)
- Completion issues (fix #33)
- Not highlighting tools / their arguments outside of the tools field (fix #34)
- Code folding for repeat blocks (fix #38)
- Don't delete the line in the "Toggle line tick type" command if the tick can't be determined (fix #40)
- Support for `autoaim ent <targetname> [lerp ticks]` syntax (fix #42)
- Show the correct tool order according to SAR in version >= 3 (and in the order they are specified otherwise) (fix #43)
- Fix for wrong `start [next] <map/cm/save> <...>` errors (fix #46)