### PR TITLE
Debug tick

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,11 @@
                     "default": true,
                     "description": "Show a piece of text at the end of the current line, showing the currently active tools in their execution order."
                 },
+                "p2tas-lang.showDebugTick": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Highlight the framebulk corresponding to the current playback/trace tick, as well as the active tools on that tick, in the editor."
+                },
                 "p2tas-lang.confirmFieldChangesInSidebar": {
                     "type": "boolean",
                     "default": true,

--- a/server/src/tas-script/tasScript.ts
+++ b/server/src/tas-script/tasScript.ts
@@ -63,7 +63,7 @@ export class TASScript {
             switch (state) {
                 case ParserState.Version:
                     this.expectText("Expected version", "version");
-                    this.scriptVersion = this.expectNumber("Invalid version", 1, 2, 3, 4) ?? 4; // Assume version 4 if not present
+                    this.scriptVersion = this.expectNumber("Invalid version", 1, 2, 3, 4, 5) ?? 5; // Assume version 5 if not present
                     this.expectCount("Ignored parameters", 2);
 
                     this.lines.set(currentLine, new ScriptLine(currentLineText, 0, false, LineType.Version, [], this.tokens[this.lineIndex]));

--- a/server/src/tas-script/tasScript.ts
+++ b/server/src/tas-script/tasScript.ts
@@ -406,11 +406,23 @@ export class TASScript {
                     }
                 }
 
-                if (tool.durationIndex === -1)
-                    activeTools.push(new TASTool.Tool(toolName));
-                else {
-                    if (toolName === "autoaim" || toolDuration !== undefined)
-                        activeTools.push(new TASTool.Tool(toolName, toolDuration));
+                if (tool.durationIndex === -1) {
+                    activeTools.push(new TASTool.Tool(
+                        toolName,
+                        this.lineIndex,
+                        toolNameToken.start,
+                        this.tokens[this.lineIndex][this.tokenIndex - 1].end,
+                    ));
+                } else {
+                    if (toolName === "autoaim" || toolDuration !== undefined) {
+                        activeTools.push(new TASTool.Tool(
+                            toolName,
+                            this.lineIndex,
+                            toolNameToken.start,
+                            this.tokens[this.lineIndex][this.tokenIndex - 1].end,
+                            toolDuration,
+                        ));
+                    }
                 }
 
                 if (this.tokenIndex >= this.tokens[this.lineIndex].length) return;
@@ -453,7 +465,13 @@ export class TASScript {
                 }
                 this.tokenIndex++;
 
-                activeTools.push(new TASTool.Tool(toolName !== "decel" ? toolName : "(decel)", toolDuration));
+                activeTools.push(new TASTool.Tool(
+                    toolName !== "decel" ? toolName : "(decel)",
+                    this.lineIndex,
+                    toolNameToken.start,
+                    this.tokens[this.lineIndex][this.tokenIndex - 2].end,
+                    toolDuration,
+                ));
             }
         }
     }

--- a/server/src/tas-script/tasTool.ts
+++ b/server/src/tas-script/tasTool.ts
@@ -85,7 +85,7 @@ export namespace TASTool {
         setang: {
             isOrderDetermined: true,
             hasOff: false,
-            durationIndex: 2,
+            durationIndex: 3,
             arguments: [
                 { type: TokenType.Number, required: true },
                 { type: TokenType.Number, required: true },
@@ -126,7 +126,7 @@ export namespace TASTool {
         check: {
             isOrderDetermined: true,
             hasOff: false,
-            durationIndex: -1,
+            durationIndex: 100, // janky hack to make this never show as an active tool
             arguments: [
                 {
                     text: "pos", type: TokenType.String, required: false, children: [

--- a/server/src/tas-script/tasTool.ts
+++ b/server/src/tas-script/tasTool.ts
@@ -4,11 +4,14 @@ export namespace TASTool {
     export class Tool {
         constructor(
             public tool: string,
-            public ticksRemaining?: number
+            public fromLine: number,
+            public startCol: number,
+            public endCol: number,
+            public ticksRemaining?: number,
         ) { }
 
         copy(): Tool {
-            return new Tool(this.tool, this.ticksRemaining);
+            return new Tool(this.tool, this.fromLine, this.startCol, this.endCol, this.ticksRemaining);
         }
     }
 


### PR DESCRIPTION
This implements a system where the framebulk corresponding to the current "debug tick" (either the current playback tick if the TAS player is active, or the trace bbox tick otherwise) is highlighted in the file, as are the tools active on that tick. I also chucked a few unrelated fixes in this PR for funsies